### PR TITLE
model.predict does not expect model.cond to return a pandas Series 

### DIFF
--- a/src/pylemur/tl/lemur.py
+++ b/src/pylemur/tl/lemur.py
@@ -379,6 +379,8 @@ class LEMUR:
 
             if isinstance(new_condition, pd.DataFrame):
                 new_design = new_condition.to_numpy()
+            elif isinstance(new_condition, pd.Series):
+                new_design = np.expand_dims(new_condition.to_numpy(), axis=0)
             elif isinstance(new_condition, np.ndarray):
                 new_design = new_condition
             else:
@@ -426,8 +428,8 @@ class LEMUR:
 
         Returns
         -------
-        `ModelMatrix`
-            A ModelMatrix instance with one row with the same columns as the design matrix.
+        `pd.Series`
+            A contrast vector that aligns to the columns of the design matrix.
 
 
         Notes


### PR DESCRIPTION
Hi, thanks for the great package.

It appears that the recent change to use `formulaic_contrasts` has introduced a bug in `model.predict()` because this function is not expecting `model.cond()` to return a pandas Series.

It appears that [previously](https://github.com/const-ae/pyLemur/blob/d42e5b5070429b96155a79d56b697418eb1327c4/src/pylemur/tl/lemur.py#L473), the return value of `model.cond()` was a pandas DataFrame but now it is a [single row](https://github.com/scverse/formulaic-contrasts/blob/76007d56b4c12374fab52b897035fb01d6c44cc9/src/formulaic_contrasts/_contrasts.py#L57), represented as a pandas Series


<img width="1326" alt="Screenshot 2024-12-10 at 11 22 25 AM" src="https://github.com/user-attachments/assets/d3b3d9e0-ebe5-4530-9fa5-a6c311fdeffc">
